### PR TITLE
netsuite-type-scraper isn't a testsuite, doesn't take a type

### DIFF
--- a/netsuite.cabal
+++ b/netsuite.cabal
@@ -87,7 +87,6 @@ test-suite unit-tests
                      , vector
 
 executable netsuite-type-scraper
-  type:                exitcode-stdio-1.0
   hs-source-dirs:      src
   main-is:             TypeScraper.hs
   default-language:    Haskell2010


### PR DESCRIPTION
`netsuite-type-scraper` was not running due to misplaced `type` field in its cabal section.

@rtrvrtg 